### PR TITLE
Build linux executibles in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,9 @@ jobs:
         shell: bash
         run: |
           python -m venv venv
-          venv/Scripts/python -m pip install --upgrade pip
-          venv/Scripts/python -m pip install -r requirements.txt
+          ls -la venv
+          venv/scripts/python -m pip install --upgrade pip
+          venv/scripts/python -m pip install -r requirements.txt
           
       - name: Create linux executable
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Make Executables
 on:
   workflow_dispatch:
 jobs:
-  pyinstaller-build:
+  pyinstaller-build-windows:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
@@ -42,3 +42,39 @@ jobs:
         with:
           name: windows-installer
           path: Output/
+
+  pyinstaller-build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          
+      - name: Create virtual environment
+        shell: cmd
+        run: |
+          python -m venv venv
+          venv\Scripts\python -m pip install --upgrade pip
+          venv\Scripts\python -m pip install -r requirements.txt
+          
+      - name: Create linux executable
+        shell: cmd
+        run: |
+           venv\Scripts\pyinstaller Flare.spec --noconfirm
+           echo "::debug::${PWD}"
+           
+      - name: Upload linux executable folder as ZIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-executable
+          path: dist/Flare/
+
+      # - name: Upload windows installer as ZIP
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: windows-installer
+      #     path: Output/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,15 +58,12 @@ jobs:
         shell: bash
         run: |
           python -m venv venv
-          ls -la venv
           venv/bin/python -m pip install --upgrade pip
           venv/bin/python -m pip install -r requirements.txt
           
       - name: Create linux executable
         shell: bash
         run: |
-           ls -la ./venv/lib/python3.13
-           find ./venv/ -name nicegui
            venv/bin/pyinstaller Flare.spec --noconfirm
            echo "::debug::${PWD}"
            

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Create linux executable
         shell: bash
         run: |
+           ls -la ./venv/lib
            venv/bin/pyinstaller Flare.spec --noconfirm
            echo "::debug::${PWD}"
            

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,13 +59,13 @@ jobs:
         run: |
           python -m venv venv
           ls -la venv
-          venv/scripts/python -m pip install --upgrade pip
-          venv/scripts/python -m pip install -r requirements.txt
+          venv/bin/python -m pip install --upgrade pip
+          venv/bin/python -m pip install -r requirements.txt
           
       - name: Create linux executable
         shell: bash
         run: |
-           venv/Scripts/pyinstaller Flare.spec --noconfirm
+           venv/bin/pyinstaller Flare.spec --noconfirm
            echo "::debug::${PWD}"
            
       - name: Upload linux executable folder as ZIP

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,14 +55,14 @@ jobs:
           python-version: '3.13'
           
       - name: Create virtual environment
-        shell: cmd
+        shell: bash
         run: |
           python -m venv venv
           venv\Scripts\python -m pip install --upgrade pip
           venv\Scripts\python -m pip install -r requirements.txt
           
       - name: Create linux executable
-        shell: cmd
+        shell: bash
         run: |
            venv\Scripts\pyinstaller Flare.spec --noconfirm
            echo "::debug::${PWD}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,13 +58,13 @@ jobs:
         shell: bash
         run: |
           python -m venv venv
-          venv\Scripts\python -m pip install --upgrade pip
-          venv\Scripts\python -m pip install -r requirements.txt
+          venv/Scripts/python -m pip install --upgrade pip
+          venv/Scripts/python -m pip install -r requirements.txt
           
       - name: Create linux executable
         shell: bash
         run: |
-           venv\Scripts\pyinstaller Flare.spec --noconfirm
+           venv/Scripts/pyinstaller Flare.spec --noconfirm
            echo "::debug::${PWD}"
            
       - name: Upload linux executable folder as ZIP

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
         shell: cmd
         run: |
            venv\Scripts\pyinstaller.exe Flare.spec --noconfirm
-           echo "::debug::%CD%"
            
       - name: Upload windows executable folder as ZIP
         uses: actions/upload-artifact@v4
@@ -65,16 +64,9 @@ jobs:
         shell: bash
         run: |
            venv/bin/pyinstaller Flare.spec --noconfirm
-           echo "::debug::${PWD}"
            
       - name: Upload linux executable folder as ZIP
         uses: actions/upload-artifact@v4
         with:
           name: linux-executable
           path: dist/Flare/
-
-      # - name: Upload windows installer as ZIP
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: windows-installer
-      #     path: Output/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,8 @@ jobs:
       - name: Create linux executable
         shell: bash
         run: |
-           ls -la ./venv/lib
+           ls -la ./venv/lib/python3.13
+           find ./venv/ -name nicegui
            venv/bin/pyinstaller Flare.spec --noconfirm
            echo "::debug::${PWD}"
            

--- a/Flare.spec
+++ b/Flare.spec
@@ -1,11 +1,10 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-
 a = Analysis(
     ['flare/main.py'],
     pathex=[],
     binaries=[],
-    datas=[('./venv/Lib/site-packages/nicegui', 'nicegui'),
+    datas=[('./venv/lib/site-packages/nicegui', 'nicegui'),
     ('./data/assets', './assets'),
     ('./data/elements', './elements'),
     ('./data/tips.md', '.'),

--- a/Flare.spec
+++ b/Flare.spec
@@ -1,10 +1,16 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import platform
+if platform.system() == "Windows":
+    venv_path = './venv/Lib/'
+else:
+    venv_path = './venv/lib/python3.13/'
+
 a = Analysis(
     ['flare/main.py'],
     pathex=[],
     binaries=[],
-    datas=[('./venv/lib/site-packages/nicegui', 'nicegui'),
+    datas=[(venv_path + '/site-packages/nicegui', 'nicegui'),
     ('./data/assets', './assets'),
     ('./data/elements', './elements'),
     ('./data/tips.md', '.'),

--- a/Flare.spec
+++ b/Flare.spec
@@ -5,11 +5,11 @@ a = Analysis(
     ['flare/main.py'],
     pathex=[],
     binaries=[],
-    datas=[('.\\venv\\Lib\\site-packages\\nicegui', 'nicegui'),
-    ('.\\data\\assets', '.\\assets'),
-    ('.\\data\\elements', '.\\elements'),
-    ('.\\data\\tips.md', '.'),
-    ('.\\data\\saves\\colors.json', '.\\saves')],
+    datas=[('./venv/Lib/site-packages/nicegui', 'nicegui'),
+    ('./data/assets', './assets'),
+    ('./data/elements', './elements'),
+    ('./data/tips.md', '.'),
+    ('./data/saves/colors.json', './saves')],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},
@@ -21,7 +21,7 @@ a = Analysis(
 
 pyz = PYZ(a.pure)
 splash = Splash(
-    '.\\data\\assets\\splash.png',
+    './data/assets/splash.png',
     binaries=a.binaries,
     datas=a.datas,
     text_pos=None,
@@ -48,7 +48,7 @@ exe = EXE(
     codesign_identity=None,
     entitlements_file=None,
     contents_directory="data",
-    icon = ".\\data\\assets\\favicon2.ico",
+    icon = "./data/assets/favicon2.ico",
 )
 coll = COLLECT(
     exe,


### PR DESCRIPTION
This pull request adds Linux executable builds to the CI. This was more or less a copy-paste of the windows build, with 2 main tweaks:
- change path separators from `\\` to `/` for  the Linux CI and for the spec file. Windows supports forwards slash as a path separator which is nice.
- change the path to the nicegui data on Linux as it is placed in a different part of the venv for some reason

You can see a successful run and the artifacts at https://github.com/DusterTheFirst/Flare/actions/runs/16554915923

The CI does not build an installer for the linux version yet.

> [!IMPORTANT]
> Merge this PR using a Squash merge, not a default merge commit. This will combine all of these commits into a single commit. You should also change the default commit description

